### PR TITLE
Parse .cfg for LINKOBJS & add to LD -o build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ endif
 
 
 SHELL:=/bin/bash
+LINKOBJS := $(shell realpath $(shell sed -n 's/^.*LINKOBJS: //p' amslah.cfg 2>/dev/null) 2>/dev/null)
+
 LIBDIRS := $(shell realpath $(shell sed -n 's/^.*LIBS: //p' amslah.cfg 2>/dev/null) 2>/dev/null)
 
 INCLUDE = -I"$(AMSLAH_PATH)/core" -I"$(AMSLAH_PATH)/config" -I"$(AMSLAH_PATH)/freertos/include" -I"$(AMSLAH_PATH)/freertos/portable_$(EDBG_FAMILY)" -I"$(AMSLAH_PATH)/extra" -I"."
@@ -144,8 +146,8 @@ COBJ := $(CSRC:%.c=%.o)
 OBJ := $(COBJ) $(CPPOBJ)
 BUILTOBJ := $(addprefix $(BUILD_PATH)/,$(OBJ))
 
-$(APP): $(BUILTOBJ) 
-	$(LD) $(LFLAGS) -o build/$(PROJECT_NAME)$(_NAME_SUFFIX).elf $(BUILTOBJ)
+$(APP): $(BUILTOBJ)
+	$(LD) $(LFLAGS) -o build/$(PROJECT_NAME)$(_NAME_SUFFIX).elf $(BUILTOBJ) $(LINKOBJS)
 	$(OBJCOPY) --strip-unneeded -O binary build/$(PROJECT_NAME)$(_NAME_SUFFIX).elf build/$(PROJECT_NAME)$(_NAME_SUFFIX).bin
 	cat hook_output
 	printf "INCLUDE: ${INCLUDE} \nCSRC: ${CSRC} \nCPPSRC: ${CPPSRC}" > build/filelist 


### PR DESCRIPTION
Per [integrate gas sensor payload into main flight code](https://app.asana.com/0/1204368090867754/1205139490439358/f), we need to link a closed source `.a` file for the zmod4510.

This PR is to generalize the process of linking arbitrary compiled obj files. 

When unspecified, the var is set to an empty string, and should not affect the default build process of [`$(LD) $(LFLAGS) -o build/$(PROJECT_NAME)$(_NAME_SUFFIX).elf $(BUILTOBJ) $(LINKOBJS)`](https://github.com/windborne/amslah/blob/e32fad47334b91e1028eeb1ffb4220966102fed1/Makefile#L148).