### PR TITLE
Support excluding build directories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ INCLUDE = -I"$(AMSLAH_PATH)/core" -I"$(AMSLAH_PATH)/config" -I"$(AMSLAH_PATH)/fr
 INCLUDE += $(foreach LIBDIR,$(LIBDIRS),-I"$(LIBDIR)")
 INCLUDE += $(foreach LIBDIR,$(shell ls -d */),-I"$(LIBDIR)")
 
-EXCLUDE := $(shell sed -n 's/^.*IGNORE: //p' amslah.cfg 2>/dev/null)
+EXCLUDE := $(shell sed -n 's/^.*EXCLUDE: //p' amslah.cfg 2>/dev/null)
 
 ifndef IGNORE_HOOK
 HOOK_VAL := $(shell $(shell sed -n 's/^.*HOOKS: //p' amslah.cfg 2>&1) &> hook_output; echo $$?)

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ INCLUDE = -I"$(AMSLAH_PATH)/core" -I"$(AMSLAH_PATH)/config" -I"$(AMSLAH_PATH)/fr
 INCLUDE += $(foreach LIBDIR,$(LIBDIRS),-I"$(LIBDIR)")
 INCLUDE += $(foreach LIBDIR,$(shell ls -d */),-I"$(LIBDIR)")
 
+EXCLUDE := $(shell sed -n 's/^.*IGNORE: //p' amslah.cfg 2>/dev/null)
 
 ifndef IGNORE_HOOK
 HOOK_VAL := $(shell $(shell sed -n 's/^.*HOOKS: //p' amslah.cfg 2>&1) &> hook_output; echo $$?)
@@ -85,6 +86,7 @@ CONFIGS += user_amslah_config.h
 DIRS = .
 DIRS += $(LIBDIRS)
 DIRS += $(shell ls -d */ | grep -v ^build| grep -v ^test)
+DIRS := $(filter-out $(EXCLUDE)/,$(DIRS))
 
 CPPSRC = $(foreach DIR,$(DIRS),$(wildcard $(DIR)/*.cpp)) 
 CSRC = $(foreach DIR,$(DIRS),$(wildcard $(DIR)/*.c)) 


### PR DESCRIPTION
Add `EXCLUDE` directory var when searching for `.h`, .c`, & `.cpp` files.

`amslah.cfg` usage:
```
EXCLUDE: x64test
```