### PR TITLE
(Fix): Allow passthrough of non expandable hook args.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ ifndef IGNORE_HOOK
 HOOKS_CMD_RAW := $(shell sed -n 's/^HOOKS: //p' amslah.cfg 2>&1)
 HOOK_VARS := $(shell echo '$(HOOKS_CMD_RAW)' | grep -o '__[^_]*__' | tr -d '_' | sort | uniq)
 
-replace_vars = $(foreach var,$(1),$(subst __$(var)__,"${$(var)}",$(2)))
+replace_vars = $(if $(1),$(foreach var,$(1),$(subst __$(var)__,"${$(var)}",$(2))),$(2))
 HOOKS_CMD := $(call replace_vars,$(HOOK_VARS),$(HOOKS_CMD_RAW))
-$(info HOOKS_CMD: `$(HOOKS_CMD)`)
+$(info HOOKS_CMD: `$(HOOKS_CMD_RAW)` --> `$(HOOKS_CMD)`)
 
 HOOK_VAL := $(shell $(HOOKS_CMD) &> hook_output; echo $$?)
 ifneq ($(HOOK_VAL), 0)


### PR DESCRIPTION
Extends: https://github.com/windborne/amslah/pull/7.

There is an edge case where no expandable args are included in the `HOOK`, which would cause `foreach` & `subst` to return `""` as there is nothing to iterate over.

This PR passes through the original hook instead.
now both of these `amslah.cfg` will work:
```cfg
HOOKS: zemi --board_rev=__REV__
HOOKS_POST: python3 check_flash.py
MCU: SAMD51N20A
CFLAGS: -Werror
```
```cfg
HOOKS: zemi
HOOKS_POST: python3 check_flash.py
MCU: SAMD51N20A
CFLAGS: -Werror
```