### PR TITLE
Add opt in bypass of i2c atomic lock

### DIFF
--- a/core/i2c.h
+++ b/core/i2c.h
@@ -34,6 +34,7 @@ typedef struct {
 	uint8_t pin_scl;
 	bool nostop;
 	bool slow;
+	bool allow_isr_during_bitbang;
 } i2c_t;
 
 void i2c_init(i2c_t *i2c, int sercom,


### PR DESCRIPTION
For Dropsonde 2.7 board, we need a way to remove atomic sections during bitbanged i2c, because these locks cause our UART interrupt handler to drop bytes, meaning we can't read from the Dangly v6 at all.

However, I want this feature to be explicitly opt in, so no other boards, i2c sercoms, or even bitbanged i2c is affected by this update to our hardware abstraction layer.